### PR TITLE
 Fix race when scanning directories

### DIFF
--- a/src/hook.ml
+++ b/src/hook.ml
@@ -10,7 +10,7 @@ module Digests = Core.Digests
 
 let (/) = Filename.concat
 
-let src = Logs.Src.create "irw-polling" ~doc:"Irmin watcher using using polling"
+let src = Logs.Src.create "irw-hook" ~doc:"Irmin watcher shared code"
 module Log = (val Logs.src_log src : Logs.LOG)
 
 let list_files kind dir =

--- a/src/hook.ml
+++ b/src/hook.ml
@@ -43,10 +43,14 @@ let rec_files dir =
   aux [] dir
 
 let read_file ~prefix f =
-  if not (Sys.file_exists f) || Sys.is_directory f then None
-  else
-  let r = String.with_range ~first:(String.length prefix) f in
-  Some (r, Digest.file f)
+  try
+    if not (Sys.file_exists f) || Sys.is_directory f then None
+    else
+    let r = String.with_range ~first:(String.length prefix) f in
+    Some (r, Digest.file f)
+  with ex ->
+    Log.info (fun fm -> fm "read_file(%s): %a" f Fmt.exn ex);
+    None
 
 let read_files dir =
   rec_files dir >|= fun new_files ->


### PR DESCRIPTION
- Fix crash (race) when scanning directories.
- Make listen loop tail-recursive.
- Clearer name for hook logger.

Fixes #20.