### PR TITLE
opam: remove the 'build' directive on dune dependency

### DIFF
--- a/irmin-watcher.opam
+++ b/irmin-watcher.opam
@@ -16,7 +16,7 @@ run-test: ["dune" "runtest" "-p" name]
 
 depends: [
   "ocaml"    {>= "4.02.0"}
-  "dune"     {build}
+  "dune"
   "alcotest" {with-test}
   "mtime"    {with-test & >= "1.0.0"}
   "lwt"


### PR DESCRIPTION
This directive results in failure when downgrading Dune versions, due to version-specific functionality in the Dune language. See https://github.com/ocaml/opam/issues/3850 for more details.