### PR TITLE
Use _WIN32 and MAX_PATH on Windows

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,7 @@
+### Pending
+
+- Use _WIN32 and MAX_PATH on Windows to support MSVC (#34, @jonahbeckford)
+
 ### 0.5.0 (2020-04-30)
 
 - Switch to GitHub Actions from Travis (#31, @avsm)

--- a/src/realpath.c
+++ b/src/realpath.c
@@ -15,7 +15,12 @@
  * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
  */
 
+#ifdef _MSC_VER
+/* https://docs.microsoft.com/en-us/windows/win32/fileio/maximum-file-path-limitation */
+#define PATH_MAX MAX_PATH
+#else
 #include <sys/param.h>
+#endif
 #include <stdlib.h>
 #include <errno.h>
 
@@ -27,7 +32,7 @@
 #include <caml/signals.h>
 #include <caml/unixsupport.h>
 
-#ifdef WIN32
+#ifdef _WIN32
 CAMLprim value irmin_watcher_unix_realpath(value path)
 {
   TCHAR buffer[PATH_MAX]=TEXT("");


### PR DESCRIPTION
This PR does two changes:

1. As in other mirage packages, changed `WIN32` macro to `_WIN32` (more below)
2. Use MAX_PATH for MSVC compiler to fill-in for missing PATH_MAX

---

According to https://reviews.llvm.org/D40285 the `_WIN32` macro works across MSVC, GCC and clang compilers:

> In MSVC, WIN32 and WIN64 are never defined by the compiler, neither by system headers. Project files created by the IDE often contains them set manually though.
>
> GCC on the other hand predefines both `_WIN32` and `WIN32` (and similarly for -64), but only when using the GNU standards additions (which are enabled by default) `x86_64-w64-mingw32-gcc -E -dM - < /dev/null | grep WIN32` does include both, while the unprefixed one vanishes if you add e.g. `-std=c99` (but are still included if you set `-std=gnu99`).
>
> clang on the other hand doesn't check the standards version, but provides both `WIN32` and `_WIN32`. And for the really inconsistent case, with `clang -target x86_64-w64-mingw32 -E -dM - < /dev/null`, you will have `WIN64`, `_WIN64` and `_WIN32`, but no unprefixed `WIN32`.

So `WIN32` is incorrect, even on GCC compilers.

The `_WIN32` macro is documented at https://docs.microsoft.com/en-us/cpp/preprocessor/predefined-macros?view=msvc-170