### PR TITLE
Fix build on Alpine 3.19 for OCaml 5.1

### DIFF
--- a/dune-project
+++ b/dune-project
@@ -22,7 +22,7 @@ irmin-watcher is distributed under the ISC license.
  (depends
    (ocaml (>= "4.02.0"))
    (alcotest :with-test)
-   (mtime (and :with-test (>= "1.0.0")))
+   (mtime (and :with-test (>= "2.0.0")))
    (inotify (= :os "linux"))
    (cf-lwt (>="0.4"))
    lwt

--- a/irmin-watcher.opam
+++ b/irmin-watcher.opam
@@ -19,7 +19,7 @@ depends: [
   "dune" {>= "2.8"}
   "ocaml" {>= "4.02.0"}
   "alcotest" {with-test}
-  "mtime" {with-test & >= "1.0.0"}
+  "mtime" {with-test & >= "2.0.0"}
   "inotify" {os = "linux"}
   "cf-lwt" {>= "0.4"}
   "lwt"

--- a/test/test.ml
+++ b/test/test.ml
@@ -132,7 +132,7 @@ let reporter () =
     in
     let ppf = match level with Logs.App -> Fmt.stdout | _ -> Fmt.stderr in
     let with_stamp h _tags k fmt =
-      let dt = Mtime.Span.to_us (Mtime_clock.elapsed ()) in
+      let dt = Mtime.Span.to_float_ns (Mtime_clock.elapsed ()) in
       Fmt.kpf k ppf
         ("%+04.0fus %a %a @[" ^^ fmt ^^ "@]@.")
         dt


### PR DESCRIPTION
The PR changes have been tested on Docker ocaml/opam:alpine-3.19-ocaml-5.1 that successfully builds irmin-watcher and runs the tests.

The libffi-dev package needs to be installed on Alpine 3.19 for the dependencies to be installed though.

```
$ sudo docker run -it ocaml/opam:alpine-3.19-ocaml-5.1 bash
$ git clone https://github.com/mirage/irmin-watcher.git
$ cd irmin-watcher
$ sudo apk add libffi-dev
$ opam install . --deps-only --with-test -y
$ dune build
$ dune test
```