### PR TITLE
Update github workflow for macos

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -24,11 +24,10 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v2
       - name: Use OCaml ${{ matrix.ocaml-version }}
-        uses: avsm/setup-ocaml@v1
+        uses: avsm/setup-ocaml@v2
         with:
-          ocaml-version: ${{ matrix.ocaml-version }}
+          ocaml-compiler: ${{ matrix.ocaml-version }}
       - run: opam pin add . --no-action
-      - run: opam depext irmin-watcher --yes --with-doc --with-test
       - run: opam install . --deps-only --with-doc --with-test
       - run: opam exec -- dune build
       - run: opam exec -- dune runtest


### PR DESCRIPTION
The deprecated `opam depext` was having issues installing odoc and its dependencies, which themselves depend on odoc to produce their documentation... Upgrading to the latest `setup-ocaml` github action allow us to remove this step as opam is able to install the depexts by itself.