### PR TITLE
Move to Eio

### DIFF
--- a/.ocamlformat
+++ b/.ocamlformat
@@ -1,4 +1,4 @@
-version = 0.18.0
+version = 0.26.1
 break-infix = fit-or-vertical
 parse-docstrings = true
 indicate-multiline-delimiters = no

--- a/src/backend.fsevents.ml
+++ b/src/backend.fsevents.ml
@@ -11,7 +11,6 @@ let src = Logs.Src.create "irw-fsevents" ~doc:"Irmin watcher using FSevents"
 module Log = (val Logs.src_log src : Logs.LOG)
 
 let create_flags = Fsevents.CreateFlags.detailed_interactive
-
 let run_loop_mode = Cf.RunLoop.Mode.Default
 
 let start_runloop dir =

--- a/src/core.ml
+++ b/src/core.ml
@@ -66,7 +66,7 @@ module Dispatch = struct
   (* call all the callbacks on the file *)
   let apply t ~dir ~file =
     let fns = try Hashtbl.find t dir with Not_found -> [] in
-    Fiber.iter
+    Fiber.List.iter
       (fun (id, f) ->
         Log.debug (fun f -> f "callback %d" id);
         f file)

--- a/src/core.mli
+++ b/src/core.mli
@@ -41,11 +41,11 @@ module Dispatch : sig
   (** [stats t ~dir] is the number of active callbacks registered for the
       directory [dir]. *)
 
-  val apply : t -> dir:string -> file:string -> unit Lwt.t
+  val apply : t -> dir:string -> file:string -> unit
   (** [apply t ~dir ~file] calls [f file] for every callback [f] registered for
       the directory [dir]. *)
 
-  val add : t -> id:int -> dir:string -> (string -> unit Lwt.t) -> unit
+  val add : t -> id:int -> dir:string -> (string -> unit) -> unit
   (** [add t ~id ~dir f] adds a new callback [f] to the directory [dir], using
       the unique identifier [id]. *)
 
@@ -66,20 +66,20 @@ module Watchdog : sig
   val dispatch : t -> Dispatch.t
   (** [dispath t] is the table of [t]'s callback dispatch. *)
 
-  type hook = (string -> unit Lwt.t) -> (unit -> unit Lwt.t) Lwt.t
+  type hook = (string -> unit) -> (unit -> unit)
   (** The type for watchdog hook. *)
 
   val empty : unit -> t
   (** [empty ()] is the empty watchdog, monitoring no directory. *)
 
-  val clear : t -> unit Lwt.t
+  val clear : t -> unit
   (** [clear ()] stops all the currently active watchdogs. *)
 
-  val start : t -> dir:string -> hook -> unit Lwt.t
+  val start : t -> dir:string -> hook -> unit
   (** [start t ~dir h] adds a new callback hook on the directory [dir], starting
       a new watchdog if needed otherwise re-using the previous one. *)
 
-  val stop : t -> dir:string -> unit Lwt.t
+  val stop : t -> dir:string -> unit
   (** [stop t ~dir] stops the filesystem watchdog on directory [dir] (if any). *)
 
   val length : t -> int
@@ -87,7 +87,7 @@ module Watchdog : sig
 end
 
 type hook =
-  int -> string -> (string -> unit Lwt.t) -> (unit -> unit Lwt.t) Lwt.t
+  int -> string -> (string -> unit) -> (unit -> unit)
 (** The type for Irmin.Watch hooks. *)
 
 type t
@@ -104,9 +104,9 @@ val hook : t -> hook
 
 (** {1 Helpers} *)
 
-val stoppable : (unit -> unit Lwt.t) -> unit -> unit Lwt.t
-(** [stoppable t] is a function [f] such that calling [f] will cancel the thread
-    [t]. *)
+val stoppable : sw:Eio.Switch.t -> (unit -> unit) -> unit -> unit
+(** [stoppable ~sw t] is a function [f] such that calling [f] will cancel the thread
+    [t]. The switch passed to the function is attached to the forked fiber for [t].  *)
 
 val default_polling_time : float ref
 

--- a/src/core.mli
+++ b/src/core.mli
@@ -66,7 +66,7 @@ module Watchdog : sig
   val dispatch : t -> Dispatch.t
   (** [dispath t] is the table of [t]'s callback dispatch. *)
 
-  type hook = (string -> unit) -> (unit -> unit)
+  type hook = (string -> unit) -> unit -> unit
   (** The type for watchdog hook. *)
 
   val empty : unit -> t
@@ -86,8 +86,7 @@ module Watchdog : sig
   (** [length t] is the number of watchdog threads. *)
 end
 
-type hook =
-  int -> string -> (string -> unit) -> (unit -> unit)
+type hook = int -> string -> (string -> unit) -> unit -> unit
 (** The type for Irmin.Watch hooks. *)
 
 type t
@@ -105,8 +104,9 @@ val hook : t -> hook
 (** {1 Helpers} *)
 
 val stoppable : sw:Eio.Switch.t -> (unit -> unit) -> unit -> unit
-(** [stoppable ~sw t] is a function [f] such that calling [f] will cancel the thread
-    [t]. The switch passed to the function is attached to the forked fiber for [t].  *)
+(** [stoppable ~sw t] is a function [f] such that calling [f] will cancel the
+    thread [t]. The switch passed to the function is attached to the forked
+    fiber for [t]. *)
 
 val default_polling_time : float ref
 

--- a/src/dune
+++ b/src/dune
@@ -6,13 +6,14 @@
  (public_name irmin-watcher)
  (libraries
   fmt
-  lwt
   logs
   astring
+  lwt_eio
+  eio.unix
   (select
    backend.ml
    from
-   (cf-lwt fsevents-lwt -> backend.fsevents.ml)
+   (cf-eio fsevents-eio -> backend.fsevents.ml)
    (inotify.lwt -> backend.inotify.ml)
    (lwt.unix -> backend.polling.ml))
   (select

--- a/src/dune
+++ b/src/dune
@@ -19,6 +19,6 @@
   (select
    backend.mli
    from
-   (cf-lwt fsevents-lwt -> backend.fsevents.mli)
+   (cf-eio fsevents-eio -> backend.fsevents.mli)
    (inotify.eio -> backend.inotify.mli)
    (lwt.unix -> backend.polling.mli))))

--- a/src/dune
+++ b/src/dune
@@ -14,11 +14,11 @@
    backend.ml
    from
    (cf-eio fsevents-eio -> backend.fsevents.ml)
-   (inotify.lwt -> backend.inotify.ml)
+   (inotify.eio -> backend.inotify.ml)
    (lwt.unix -> backend.polling.ml))
   (select
    backend.mli
    from
    (cf-lwt fsevents-lwt -> backend.fsevents.mli)
-   (inotify.lwt -> backend.inotify.mli)
+   (inotify.eio -> backend.inotify.mli)
    (lwt.unix -> backend.polling.mli))))

--- a/src/hook.ml
+++ b/src/hook.ml
@@ -85,7 +85,7 @@ let rec poll n ~callback ~wait_for_changes dir files (event : event) =
     else (
       Log.debug (fun f -> f "[%d] polling %s: diff:%a" n dir Digests.pp diff);
       let files = Digests.files diff in
-      Fiber.iter callback files)
+      Fiber.List.iter callback files)
   in
   process ();
   let event = wait_for_changes () in

--- a/src/hook.ml
+++ b/src/hook.ml
@@ -8,6 +8,10 @@ open Eio
 open Astring
 module Digests = Core.Digests
 
+type _ Effect.t += Top_switch : Eio.Switch.t Effect.t
+
+let top_switch () = Effect.perform Top_switch
+
 let ( / ) = Filename.concat
 
 let src = Logs.Src.create "irw-hook" ~doc:"Irmin watcher shared code"

--- a/src/hook.ml
+++ b/src/hook.ml
@@ -9,7 +9,6 @@ open Astring
 module Digests = Core.Digests
 
 let ( / ) = Filename.concat
-
 let src = Logs.Src.create "irw-hook" ~doc:"Irmin watcher shared code"
 
 module Log = (val Logs.src_log src : Logs.LOG)
@@ -64,14 +63,14 @@ type event = [ `Unknown | `File of string ]
 let rec poll n ~callback ~wait_for_changes dir files (event : event) =
   let new_files =
     match event with
-      | `Unknown -> read_files dir
-      | `File f -> (
-      let prefix = dir / "" in
-      let short_f = String.with_range ~first:(String.length prefix) f in
-      let files = Digests.filter (fun (x, _) -> x <> short_f) files in
-      match read_file ~prefix f with
-      | None -> files
-      | Some d -> Digests.add d files)
+    | `Unknown -> read_files dir
+    | `File f -> (
+        let prefix = dir / "" in
+        let short_f = String.with_range ~first:(String.length prefix) f in
+        let files = Digests.filter (fun (x, _) -> x <> short_f) files in
+        match read_file ~prefix f with
+        | None -> files
+        | Some d -> Digests.add d files)
   in
   Log.debug (fun l ->
       l "files=%a new_files=%a" Digests.pp files Digests.pp new_files);

--- a/src/hook.ml
+++ b/src/hook.ml
@@ -8,10 +8,6 @@ open Eio
 open Astring
 module Digests = Core.Digests
 
-type _ Effect.t += Top_switch : Eio.Switch.t Effect.t
-
-let top_switch () = Effect.perform Top_switch
-
 let ( / ) = Filename.concat
 
 let src = Logs.Src.create "irw-hook" ~doc:"Irmin watcher shared code"

--- a/src/hook.mli
+++ b/src/hook.mli
@@ -13,10 +13,10 @@ open Core
 type event = [ `Unknown | `File of string ]
 (** The type for change event. *)
 
-val v : wait_for_changes:(unit -> event Lwt.t) -> dir:string -> Watchdog.hook
-(** [v ~wait_for_changes ~dir] is the watchdog hook using [wait_for_changes] to
+val v : sw:Eio.Switch.t -> wait_for_changes:(unit -> event) -> dir:string -> Watchdog.hook
+(** [v ~sw ~wait_for_changes ~dir] is the watchdog hook using [wait_for_changes] to
     detect filesystem updates in the directory [dir]. The polling implemention
-    just calls [Lwt_unix.sleep]. *)
+    just calls [Lwt_unix.sleep]. The switch is used for the forked callback function. *)
 
 (*---------------------------------------------------------------------------
    Copyright (c) 2016 Thomas Gazagnaire

--- a/src/hook.mli
+++ b/src/hook.mli
@@ -10,6 +10,10 @@
 
 open Core
 
+type _ Effect.t += Top_switch : Eio.Switch.t Effect.t
+
+val top_switch : unit -> Eio.Switch.t
+
 type event = [ `Unknown | `File of string ]
 (** The type for change event. *)
 

--- a/src/hook.mli
+++ b/src/hook.mli
@@ -13,10 +13,15 @@ open Core
 type event = [ `Unknown | `File of string ]
 (** The type for change event. *)
 
-val v : sw:Eio.Switch.t -> wait_for_changes:(unit -> event) -> dir:string -> Watchdog.hook
-(** [v ~sw ~wait_for_changes ~dir] is the watchdog hook using [wait_for_changes] to
-    detect filesystem updates in the directory [dir]. The polling implemention
-    just calls [Lwt_unix.sleep]. The switch is used for the forked callback function. *)
+val v :
+  sw:Eio.Switch.t ->
+  wait_for_changes:(unit -> event) ->
+  dir:string ->
+  Watchdog.hook
+(** [v ~sw ~wait_for_changes ~dir] is the watchdog hook using [wait_for_changes]
+    to detect filesystem updates in the directory [dir]. The polling
+    implemention just calls [Lwt_unix.sleep]. The switch is used for the forked
+    callback function. *)
 
 (*---------------------------------------------------------------------------
    Copyright (c) 2016 Thomas Gazagnaire

--- a/src/hook.mli
+++ b/src/hook.mli
@@ -10,10 +10,6 @@
 
 open Core
 
-type _ Effect.t += Top_switch : Eio.Switch.t Effect.t
-
-val top_switch : unit -> Eio.Switch.t
-
 type event = [ `Unknown | `File of string ]
 (** The type for change event. *)
 

--- a/src/irmin_watcher.ml
+++ b/src/irmin_watcher.ml
@@ -20,6 +20,16 @@ let stats () =
 let set_polling_time f =
   match mode with `Polling -> Core.default_polling_time := f | _ -> ()
 
+let run fn =
+  Eio.Switch.run @@ fun sw ->
+  let open Effect.Deep in
+  try_with fn () {
+    effc = fun (type a) (e : a Effect.t) ->
+      match e with
+      | Hook.Top_switch -> Some (fun (k : (a, _) continuation) -> continue k sw)
+      | _ -> None
+  }
+
 (*---------------------------------------------------------------------------
    Copyright (c) 2016 Thomas Gazagnaire
 

--- a/src/irmin_watcher.ml
+++ b/src/irmin_watcher.ml
@@ -5,9 +5,7 @@
   ---------------------------------------------------------------------------*)
 
 let v ~sw = Lazy.force (Backend.v ~sw)
-
 let mode = (Backend.mode :> [ `FSEvents | `Inotify | `Polling ])
-
 let hook ~sw = Core.hook (v ~sw)
 
 type stats = { watchdogs : int; dispatches : int }

--- a/src/irmin_watcher.mli
+++ b/src/irmin_watcher.mli
@@ -28,6 +28,9 @@ val set_polling_time : float -> unit
 (** [set_polling_time f] set the polling interval to [f]. Only valid when
     [mode = `Polling]. *)
 
+val run : (unit -> 'a) -> 'a
+(** Handles calls to the {! Hook.Top_switch} effect *)
+
 (*---------------------------------------------------------------------------
    Copyright (c) 2016 Thomas Gazagnaire
 

--- a/src/irmin_watcher.mli
+++ b/src/irmin_watcher.mli
@@ -8,7 +8,7 @@
 
     {e %%VERSION%% — {{:%%PKG_HOMEPAGE%%} homepage}} *)
 
-val v : Core.t
+val v : sw:Eio.Switch.t -> Core.t
 (** [v id p f] is the listen hook calling [f] everytime a sub-path of [p] is
     modified. Return a function to call to remove the hook. Default to polling
     if no better solution is available. FSevents and Inotify backends are
@@ -18,18 +18,15 @@ val mode : [ `FSEvents | `Inotify | `Polling ]
 
 type stats = { watchdogs : int; dispatches : int }
 
-val hook : Core.hook
+val hook : sw:Eio.Switch.t -> Core.hook
 (** [hook t] is an {!Irmin.Watcher} compatible representation of {!v}. *)
 
-val stats : unit -> stats
+val stats : sw:Eio.Switch.t -> unit -> stats
 (** [stats ()] is a snapshot of [v]'s stats. *)
 
 val set_polling_time : float -> unit
 (** [set_polling_time f] set the polling interval to [f]. Only valid when
     [mode = `Polling]. *)
-
-val run : (unit -> 'a) -> 'a
-(** Handles calls to the {! Hook.Top_switch} effect *)
 
 (*---------------------------------------------------------------------------
    Copyright (c) 2016 Thomas Gazagnaire

--- a/src/polling.ml
+++ b/src/polling.ml
@@ -18,11 +18,11 @@ let with_delay ~sw delay =
 
 let mode = `Polling
 
-let v ~sw =
+let v =
   let wait_for_changes () =
     Eio_unix.sleep !Core.default_polling_time |> fun () -> `Unknown
   in
-  lazy (Core.create (listen ~sw ~wait_for_changes))
+  lazy (let sw = Hook.top_switch () in Core.create (listen ~sw ~wait_for_changes))
 
 (*---------------------------------------------------------------------------
    Copyright (c) 2016 Thomas Gazagnaire

--- a/src/polling.ml
+++ b/src/polling.ml
@@ -8,13 +8,14 @@ let src = Logs.Src.create "irw-polling" ~doc:"Irmin watcher using using polling"
 
 module Log = (val Logs.src_log src : Logs.LOG)
 
-let listen ~sw ~wait_for_changes dir =
+let listen ~wait_for_changes dir =
   Log.info (fun l -> l "Polling mode");
+  let sw = Hook.top_switch () in 
   Hook.v ~sw ~wait_for_changes ~dir
 
-let with_delay ~sw delay =
+let with_delay delay =
   let wait_for_changes () = Eio_unix.sleep delay |> fun () -> `Unknown in
-  Core.create (listen ~sw ~wait_for_changes)
+  Core.create (listen ~wait_for_changes)
 
 let mode = `Polling
 
@@ -22,7 +23,7 @@ let v =
   let wait_for_changes () =
     Eio_unix.sleep !Core.default_polling_time |> fun () -> `Unknown
   in
-  lazy (let sw = Hook.top_switch () in Core.create (listen ~sw ~wait_for_changes))
+  lazy (Core.create (listen ~wait_for_changes))
 
 (*---------------------------------------------------------------------------
    Copyright (c) 2016 Thomas Gazagnaire

--- a/src/polling.ml
+++ b/src/polling.ml
@@ -4,27 +4,25 @@
    %%NAME%% %%VERSION%%
   ---------------------------------------------------------------------------*)
 
-open Lwt.Infix
-
 let src = Logs.Src.create "irw-polling" ~doc:"Irmin watcher using using polling"
 
 module Log = (val Logs.src_log src : Logs.LOG)
 
-let listen ~wait_for_changes dir =
+let listen ~sw ~wait_for_changes dir =
   Log.info (fun l -> l "Polling mode");
-  Hook.v ~wait_for_changes ~dir
+  Hook.v ~sw ~wait_for_changes ~dir
 
-let with_delay delay =
-  let wait_for_changes () = Lwt_unix.sleep delay >|= fun () -> `Unknown in
-  Core.create (listen ~wait_for_changes)
+let with_delay ~sw delay =
+  let wait_for_changes () = Eio_unix.sleep delay |> fun () -> `Unknown in
+  Core.create (listen ~sw ~wait_for_changes)
 
 let mode = `Polling
 
-let v =
+let v ~sw =
   let wait_for_changes () =
-    Lwt_unix.sleep !Core.default_polling_time >|= fun () -> `Unknown
+    Eio_unix.sleep !Core.default_polling_time |> fun () -> `Unknown
   in
-  lazy (Core.create (listen ~wait_for_changes))
+  lazy (Core.create (listen ~sw ~wait_for_changes))
 
 (*---------------------------------------------------------------------------
    Copyright (c) 2016 Thomas Gazagnaire

--- a/src/polling.ml
+++ b/src/polling.ml
@@ -8,22 +8,21 @@ let src = Logs.Src.create "irw-polling" ~doc:"Irmin watcher using using polling"
 
 module Log = (val Logs.src_log src : Logs.LOG)
 
-let listen ~wait_for_changes dir =
+let listen ~sw ~wait_for_changes dir =
   Log.info (fun l -> l "Polling mode");
-  let sw = Hook.top_switch () in 
   Hook.v ~sw ~wait_for_changes ~dir
 
-let with_delay delay =
+let with_delay ~sw delay =
   let wait_for_changes () = Eio_unix.sleep delay |> fun () -> `Unknown in
-  Core.create (listen ~wait_for_changes)
+  Core.create (listen ~sw ~wait_for_changes)
 
 let mode = `Polling
 
-let v =
+let v ~sw =
   let wait_for_changes () =
     Eio_unix.sleep !Core.default_polling_time |> fun () -> `Unknown
   in
-  lazy (Core.create (listen ~wait_for_changes))
+  lazy (Core.create (listen ~sw ~wait_for_changes))
 
 (*---------------------------------------------------------------------------
    Copyright (c) 2016 Thomas Gazagnaire

--- a/src/polling.mli
+++ b/src/polling.mli
@@ -16,7 +16,7 @@ val with_delay : sw:Switch.t -> float -> t
     [p] is modified. Return a function to call to remove the hook. Active
     polling is done every [delay] seconds. *)
 
-val v : sw:Switch.t -> t Lazy.t
+val v : t Lazy.t
 (** [v] is [with_delay !default_polling_time]. *)
 
 val mode : [ `Polling ]

--- a/src/polling.mli
+++ b/src/polling.mli
@@ -9,9 +9,8 @@
     {e %%VERSION%% — {{:%%PKG_HOMEPAGE%%} homepage}} *)
 
 open Core
-open Eio
 
-val with_delay : sw:Switch.t -> float -> t
+val with_delay : float -> t
 (** [with_delay delay id p f] is the hook calling [f] everytime a sub-path of
     [p] is modified. Return a function to call to remove the hook. Active
     polling is done every [delay] seconds. *)

--- a/src/polling.mli
+++ b/src/polling.mli
@@ -9,13 +9,14 @@
     {e %%VERSION%% — {{:%%PKG_HOMEPAGE%%} homepage}} *)
 
 open Core
+open Eio
 
-val with_delay : float -> t
+val with_delay : sw:Switch.t -> float -> t
 (** [with_delay delay id p f] is the hook calling [f] everytime a sub-path of
     [p] is modified. Return a function to call to remove the hook. Active
     polling is done every [delay] seconds. *)
 
-val v : t Lazy.t
+val v : sw:Switch.t -> t Lazy.t
 (** [v] is [with_delay !default_polling_time]. *)
 
 val mode : [ `Polling ]

--- a/src/polling.mli
+++ b/src/polling.mli
@@ -10,12 +10,12 @@
 
 open Core
 
-val with_delay : float -> t
+val with_delay : sw:Eio.Switch.t -> float -> t
 (** [with_delay delay id p f] is the hook calling [f] everytime a sub-path of
     [p] is modified. Return a function to call to remove the hook. Active
     polling is done every [delay] seconds. *)
 
-val v : t Lazy.t
+val v : sw:Eio.Switch.t -> t Lazy.t
 (** [v] is [with_delay !default_polling_time]. *)
 
 val mode : [ `Polling ]

--- a/test/dune
+++ b/test/dune
@@ -1,6 +1,6 @@
 (executable
  (name test)
- (libraries alcotest logs.fmt irmin-watcher mtime mtime.clock.os))
+ (libraries alcotest logs.fmt eio_main irmin-watcher mtime mtime.clock.os))
 
 (rule
  (alias runtest)

--- a/test/test.ml
+++ b/test/test.ml
@@ -1,7 +1,6 @@
 open Eio
 
 let ( / ) = Filename.concat
-
 let tmpdir = Filename.get_temp_dir_name () / "irmin-watcher"
 
 let clean () =
@@ -34,7 +33,7 @@ let remove f =
   try Unix.unlink (tmpdir / f) with e -> Alcotest.fail (Printexc.to_string e)
 
 let poll ~mkdir:m i () =
-  Eio.Switch.run @@ fun sw -> 
+  Eio.Switch.run @@ fun sw ->
   if m then mkdir tmpdir;
   let events = ref [] in
   let cond = Condition.create () in
@@ -46,19 +45,21 @@ let poll ~mkdir:m i () =
   let reset () = events := [] in
   let rec wait ?n () =
     match !events with
-    | [] -> Condition.await_no_mutex cond; wait ?n ()
+    | [] ->
+        Condition.await_no_mutex cond;
+        wait ?n ()
     | e -> (
         match n with
         | None ->
             reset ();
             e
         | Some n ->
-            if List.length e < n then begin
+            if List.length e < n then (
               Condition.await_no_mutex cond;
-              wait ~n ()
-            end
+              wait ~n ())
             else (
-              reset (); e))
+              reset ();
+              e))
   in
 
   write "foo" ("foo" ^ string_of_int i);
@@ -102,7 +103,9 @@ let random_polls n () =
   mkdir tmpdir;
   let rec aux = function
     | 0 -> ()
-    | i -> poll ~mkdir:false i (); aux (i - 1)
+    | i ->
+        poll ~mkdir:false i ();
+        aux (i - 1)
   in
   prepare_fs n;
   match Irmin_watcher.mode with `Polling -> aux 10 | _ -> aux 100


### PR DESCRIPTION
This PR contains the work of @patricoferris that moves irmin-watcher to Eio.
It additionally changes the way switches are accessed to be in line with the current work in irmin.
`ocamlformat` has also been bumped from `0.18.0` to `0.26.1`